### PR TITLE
Feature/#52 post page UI

### DIFF
--- a/src/app/(client)/challenges/post/[id]/page.tsx
+++ b/src/app/(client)/challenges/post/[id]/page.tsx
@@ -1,7 +1,8 @@
 import ChallengePostForm from '@/components/features/challenges/post/challenge-post-form';
 import { fetchGetChallengeById } from '@/lib/api/challenge.api';
+import { getUserInfo } from '@/lib/api/user-Info.api';
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
 export async function generateMetadata({ params }: { params: { id: number } }): Promise<Metadata> {
   const challenge = await fetchGetChallengeById(Number(params.id));
@@ -30,6 +31,11 @@ export async function generateMetadata({ params }: { params: { id: number } }): 
 const ChallengeEditPage = async ({ params }: { params: { id: string } }) => {
   const challenge = await fetchGetChallengeById(Number(params.id));
   if (!challenge) return notFound();
+
+  const { userId } = await getUserInfo();
+  if (challenge.creatorId !== userId) {
+    redirect('/home?error=no_permission');
+  }
 
   return <ChallengePostForm mode="edit" initialData={challenge} />;
 };

--- a/src/components/features/challenges/post/challenge-post-button-group.tsx
+++ b/src/components/features/challenges/post/challenge-post-button-group.tsx
@@ -44,7 +44,7 @@ const ChallengePostButtonGroup = ({
   };
 
   return (
-    <div className="flex justify-center gap-6">
+    <div className="mb-6 flex justify-center gap-6">
       <Button variant="secondary" onClick={handleGoBack}>
         뒤로가기
       </Button>

--- a/src/components/features/challenges/post/challenge-post-button-group.tsx
+++ b/src/components/features/challenges/post/challenge-post-button-group.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
+import APP_URL from '@/constants/app-url.constant';
 import URL from '@/constants/app-url.constant';
 import useChallengePostMutation from '@/lib/hooks/use-challenge-post-mutation';
-import browserClient from '@/lib/supabase/client';
 import { ChallengePost } from '@/types/challenge.type';
 import { useRouter } from 'next/navigation';
 
@@ -19,8 +19,7 @@ const ChallengePostButtonGroup = ({
   challengeId
 }: ChallengePostButtonGroupProps) => {
   const router = useRouter();
-
-  const { mutate: handleChallengeMutation, isPending } = useChallengePostMutation({
+  const { mutateAsync, isPending } = useChallengePostMutation({
     isEditMode,
     challenge,
     challengeImageFile,
@@ -29,12 +28,19 @@ const ChallengePostButtonGroup = ({
 
   const handleSubmitChallenge = async () => {
     try {
-      await browserClient.auth.refreshSession();
-      handleChallengeMutation();
+      const result = await mutateAsync();
+      if (result.success) {
+        alert(isEditMode ? '챌린지 수정 완료!' : '챌린지 생성 완료!');
+        router.push(isEditMode ? APP_URL.CHALLENGES_ID(challengeId!) : APP_URL.HOME);
+      } else {
+        alert(`오류: ${result.message}`);
+      }
     } catch (error) {
-      console.error(error);
+      const message = error instanceof Error ? error.message : '알 수 없는 오류';
+      alert(`오류 발생: ${message}`);
     }
   };
+
   const handleGoBack = () => {
     if (window.history.length > 1) {
       router.back();

--- a/src/components/features/challenges/post/challenge-post-form.tsx
+++ b/src/components/features/challenges/post/challenge-post-form.tsx
@@ -16,25 +16,32 @@ const ChallengePostForm = ({ mode, initialData }: ChallengeFormProps) => {
   const { challenge, challengeImageFile, setters, handleChange } = useChallengeForm(initialData);
 
   return (
-    <section className="mx-auto mb-6 max-w-[320px] p-6 md:max-w-[640px]">
-      <h1 className="mb-6 text-2xl font-bold">{mode === 'create' ? '챌린지 생성' : '챌린지 수정'}</h1>
-
-      <ChallengePostInput challenge={challenge} handleChange={handleChange} />
-
-      <section className="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
-        <ChallengePostSelector challenge={challenge} setters={setters} />
-        <ChallengePostImageUploader setters={setters} challenge={challenge} />
-      </section>
-
-      <div className="flex justify-center gap-6">
-        <ChallengePostButtonGroup
-          challenge={challenge}
-          challengeImageFile={challengeImageFile}
-          isEditMode={mode === 'edit'}
-          challengeId={initialData?.id}
-        />
+    <>
+      <div className="relative mx-auto mt-24 w-full max-w-[1200px] px-5 sm:px-6 md:px-8">
+        <div className="bg-gray absolute right-10 bottom-0 left-10 h-px"></div>
+        <h1 className="relative mx-auto ml-15 inline-block border-b-3 border-black pb-1 text-2xl font-extrabold md:ml-25">
+          {mode === 'create' ? '챌린지 생성' : '챌린지 수정'}
+        </h1>
       </div>
-    </section>
+
+      <section className="mx-auto mb-6 max-w-[320px] p-6 md:max-w-[640px]">
+        <ChallengePostInput challenge={challenge} handleChange={handleChange} />
+
+        <section className="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+          <ChallengePostSelector challenge={challenge} setters={setters} />
+          <ChallengePostImageUploader setters={setters} challenge={challenge} />
+        </section>
+
+        <div className="flex justify-center gap-6">
+          <ChallengePostButtonGroup
+            challenge={challenge}
+            challengeImageFile={challengeImageFile}
+            isEditMode={mode === 'edit'}
+            challengeId={initialData?.id}
+          />
+        </div>
+      </section>
+    </>
   );
 };
 

--- a/src/components/features/challenges/post/challenge-post-form.tsx
+++ b/src/components/features/challenges/post/challenge-post-form.tsx
@@ -17,17 +17,17 @@ const ChallengePostForm = ({ mode, initialData }: ChallengeFormProps) => {
 
   return (
     <>
-      <div className="relative mx-auto mt-24 w-full max-w-[1200px] px-5 sm:px-6 md:px-8">
+      <div className="relative mx-auto mb-6 w-full max-w-[1200px] px-6 pt-6 md:px-8">
         <div className="bg-gray absolute right-10 bottom-0 left-10 h-px"></div>
         <h1 className="relative mx-auto ml-15 inline-block border-b-3 border-black pb-1 text-2xl font-extrabold md:ml-25">
           {mode === 'create' ? '챌린지 생성' : '챌린지 수정'}
         </h1>
       </div>
 
-      <section className="mx-auto mb-6 max-w-[320px] p-6 md:max-w-[640px]">
+      <section className="mx-auto flex max-w-[320px] flex-col gap-4 p-6 md:max-w-[640px]">
         <ChallengePostInput challenge={challenge} handleChange={handleChange} />
 
-        <section className="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+        <section className="mb-10 grid grid-cols-1 gap-6 md:grid-cols-2">
           <ChallengePostSelector challenge={challenge} setters={setters} />
           <ChallengePostImageUploader setters={setters} challenge={challenge} />
         </section>

--- a/src/components/features/challenges/post/challenge-post-image-uploader.tsx
+++ b/src/components/features/challenges/post/challenge-post-image-uploader.tsx
@@ -1,5 +1,7 @@
+import { cn } from '@/lib/utils';
 import { ChallengePostSetters } from '@/types/challenge-post.type';
 import { ChallengePost } from '@/types/challenge.type';
+import { UploadIcon } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 
@@ -33,13 +35,25 @@ const ChallengePostImageUploader = ({ setters, challenge }: ChallengePostImageUp
     }
   };
   return (
-    <section className="flex flex-col items-center justify-center gap-2">
-      <label className="text-lg font-semibold" htmlFor="image-upload">
+    <section className="flex flex-col items-center justify-center gap-3">
+      <label
+        htmlFor="image-upload"
+        className="text-foreground hover:text-primary text-lg font-semibold transition-colors"
+      >
         챌린지 이미지
       </label>
+
+      {/* 이미지 업로드*/}
       <div
-        className="border-border flex items-center justify-center rounded-lg border-1 border-dashed p-1 hover:cursor-pointer"
+        className={cn(
+          'group relative flex items-center justify-center rounded-lg border-2 border-dashed',
+          'border-border hover:border-secondary hover:bg-accent/10',
+          'cursor-pointer transition-colors duration-200',
+          'h-[150px] w-[250px]'
+        )}
         onClick={handleClick}
+        role="button"
+        aria-labelledby="image-upload-label"
       >
         <input
           type="file"
@@ -49,17 +63,21 @@ const ChallengePostImageUploader = ({ setters, challenge }: ChallengePostImageUp
           onChange={handleFileChange}
           ref={inputRef}
         />
-        <div className="bg-muted relative h-[140px] w-[240px] overflow-hidden rounded-lg">
+
+        {/* 미리보기 */}
+        <div className="absolute inset-0 flex items-center justify-center overflow-hidden rounded-[calc(0.5rem-2px)]">
           {previewImage ? (
             <Image
               src={previewImage}
-              alt="미리보기 이미지"
+              alt="업로드된 챌린지 이미지"
               fill
-              className="aspect-video w-full object-cover object-center"
+              className="object-cover object-center"
+              priority
             />
           ) : (
-            <div className="bg-muted flex h-[140px] w-[240px] items-center justify-center">
-              <p className="text-muted-foreground">이미지를 업로드하세요</p>
+            <div className="flex flex-col items-center gap-2 p-4 text-center">
+              <UploadIcon className="text-muted-foreground group-hover:text-secondary h-8 w-8" />
+              <p className="text-muted-foreground group-hover:text-secondary">이미지를 업로드하세요</p>
             </div>
           )}
         </div>

--- a/src/components/features/challenges/post/challenge-post-image-uploader.tsx
+++ b/src/components/features/challenges/post/challenge-post-image-uploader.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@/lib/utils';
 import { ChallengePostSetters } from '@/types/challenge-post.type';
 import { ChallengePost } from '@/types/challenge.type';
 import { UploadIcon } from 'lucide-react';
@@ -36,21 +35,15 @@ const ChallengePostImageUploader = ({ setters, challenge }: ChallengePostImageUp
   };
   return (
     <section className="flex flex-col items-center justify-center gap-3">
-      <label
-        htmlFor="image-upload"
-        className="text-foreground hover:text-primary text-lg font-semibold transition-colors"
-      >
+      <label htmlFor="image-upload" className="text-foreground text-lg font-semibold">
         챌린지 이미지
       </label>
 
       {/* 이미지 업로드*/}
       <div
-        className={cn(
-          'group relative flex items-center justify-center rounded-lg border-2 border-dashed',
-          'border-border hover:border-secondary hover:bg-accent/10',
-          'cursor-pointer transition-colors duration-200',
-          'h-[150px] w-[250px]'
-        )}
+        className={
+          'group border-border hover:border-secondary hover:bg-accent/10 relative flex h-[150px] w-[250px] cursor-pointer items-center justify-center rounded-lg border-2 border-dashed transition-colors duration-200'
+        }
         onClick={handleClick}
         role="button"
         aria-labelledby="image-upload-label"

--- a/src/components/features/challenges/post/challenge-post-input.tsx
+++ b/src/components/features/challenges/post/challenge-post-input.tsx
@@ -21,6 +21,7 @@ const ChallengePostInput = ({ challenge, handleChange }: ChallengePostInputProps
           placeholder="챌린지 제목을 입력해 주세요(30자 이내)"
           value={challenge.title}
           onChange={handleChange}
+          className="text-[14px]"
         />
       </section>
 
@@ -35,6 +36,7 @@ const ChallengePostInput = ({ challenge, handleChange }: ChallengePostInputProps
           rows={4}
           value={challenge.description}
           onChange={handleChange}
+          className="text-[14px]"
         />
       </section>
     </>

--- a/src/components/features/challenges/post/challenge-post-selector.tsx
+++ b/src/components/features/challenges/post/challenge-post-selector.tsx
@@ -98,8 +98,8 @@ const ChallengePostSelector = ({ challenge, setters }: ChallengePostSelectorProp
       </section>
 
       {/* 시작/종료 날짜 */}
-      <section>
-        <h2 className="flex flex-col gap-2">시작/종료 날짜</h2>
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">시작/종료 날짜</h2>
 
         <ChallengePostDatePicker
           startDate={challenge.startDate ? new Date(challenge.startDate) : undefined}

--- a/src/components/features/challenges/post/challenge-post-selector.tsx
+++ b/src/components/features/challenges/post/challenge-post-selector.tsx
@@ -41,11 +41,11 @@ const ChallengePostSelector = ({ challenge, setters }: ChallengePostSelectorProp
   };
 
   return (
-    <div>
+    <div className="flex flex-col gap-6">
       {/* 반복 일정 */}
-      <section className="mb-6">
-        <div className="mb-2 flex items-center justify-between">
-          <label className="mb-2 text-lg font-semibold">반복 일정</label>
+      <section className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <label className="text-lg font-semibold">반복 일정</label>
           <div>
             <input
               type="checkbox"
@@ -54,16 +54,14 @@ const ChallengePostSelector = ({ challenge, setters }: ChallengePostSelectorProp
               checked={isEveryDayChecked}
               onChange={handleEveryDayChange}
             />
-            <label htmlFor="every-day" className="mr-6">
-              매일
-            </label>
+            <label htmlFor="every-day">매일</label>
           </div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-1">
           {DAYS.map((day) => (
             <label
               key={day}
-              className={`${getDayCheckboxClass(day, challenge.executeDays)} flex items-center justify-center`}
+              className={`${getDayCheckboxClass(day, challenge.executeDays)} flex items-center justify-center font-semibold`}
             >
               <input
                 type="checkbox"
@@ -80,9 +78,9 @@ const ChallengePostSelector = ({ challenge, setters }: ChallengePostSelectorProp
       </section>
 
       {/* 챌린지 유형 */}
-      <section className="mb-6">
-        <h2 className="mb-2 text-lg font-semibold">챌린지 유형</h2>
-        <div className="flex gap-2">
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">챌린지 유형</h2>
+        <div className="flex gap-1">
           {categories.map((category) => (
             <label key={category} className={getCategoryRadioClass(category, challenge.category)}>
               <input
@@ -101,7 +99,7 @@ const ChallengePostSelector = ({ challenge, setters }: ChallengePostSelectorProp
 
       {/* 시작/종료 날짜 */}
       <section>
-        <h2 className="mb-2 text-lg font-semibold">시작/종료 날짜</h2>
+        <h2 className="flex flex-col gap-2">시작/종료 날짜</h2>
 
         <ChallengePostDatePicker
           startDate={challenge.startDate ? new Date(challenge.startDate) : undefined}

--- a/src/constants/challenge-post.constants.ts
+++ b/src/constants/challenge-post.constants.ts
@@ -2,19 +2,34 @@ import { z } from 'zod';
 
 export const DAYS = ['월', '화', '수', '목', '금', '토', '일'];
 export const SUPABASE_STORAGE_BUCKET = 'challenge-images';
-export const FETCH_MESSAGES = {
-  REQUIRED_FIELDS: '모든 필수 정보를 입력해 주세요.',
-  IMAGE_UPLOAD_FAILED: '이미지 업로드에 실패했습니다.',
-  LOGIN_REQUIRED: '로그인 후 사용 가능합니다.',
-  CHALLENGE_CREATION_FAILED: '챌린지 생성에 실패했습니다.',
-  CHALLENGE_CREATION_SUCCESS: '챌린지가 성공적으로 생성되었습니다!',
-  IMAGE_TYPE_INVALID: '허용되지 않는 파일 형식입니다. PNG 또는 JPG 파일만 업로드 가능합니다.',
-  IMAGE_SIZE_TOO_LARGE: '이미지 크기는 3MB 이하로 업로드 가능합니다.'
-};
 export const DATABASE = {
   TABLES: {
     CHALLENGES: 'challenges',
     PARTICIPANTS: 'participants'
+  }
+};
+export const STORAGE_MESSAGES = {
+  IMAGE_UPLOAD_FAILED: '이미지 업로드에 실패했습니다.',
+  IMAGE_TYPE_INVALID: '허용되지 않는 파일 형식입니다. PNG 또는 JPG 파일만 업로드 가능합니다.',
+  IMAGE_SIZE_TOO_LARGE: '이미지 크기는 3MB 이하로 업로드 가능합니다.'
+};
+export const CHALLENGE_API_MESSAGES = {
+  CREATION: {
+    SUCCESS: '챌린지 생성 성공',
+    FAILED: '챌린지 생성에 실패했습니다.'
+  },
+  UPDATE: {
+    SUCCESS: '챌린지 수정 성공',
+    FAILED: '챌린지 수정에 실패했습니다.',
+    NOT_FOUND: '해당 챌린지를 찾을 수 없습니다.',
+    UNAUTHORIZED: '이 챌린지의 수정 권한이 없습니다.',
+    NO_CHANGES: '챌린지 수정 반영 안됨'
+  },
+  IMAGE: {
+    UPLOAD_FAILED: '이미지 업로드 실패'
+  },
+  AUTH: {
+    LOGIN_REQUIRED: '로그인이 필요합니다.'
   }
 };
 export const ChallengePostSchema = {
@@ -25,3 +40,4 @@ export const ChallengePostSchema = {
   CATEGORY_SCHEMA: z.string({ required_error: '카테고리를 선택해 주세요.' }),
   EXECUTE_DAYS_SCHEMA: z.array(z.string()).min(1, '실행 요일을 선택해 주세요.')
 };
+

--- a/src/constants/challenge-post.constants.ts
+++ b/src/constants/challenge-post.constants.ts
@@ -8,7 +8,7 @@ export const DATABASE = {
     PARTICIPANTS: 'participants'
   }
 };
-export const STORAGE_MESSAGES = {
+export const FETCH_MESSAGES = {
   IMAGE_UPLOAD_FAILED: '이미지 업로드에 실패했습니다.',
   IMAGE_TYPE_INVALID: '허용되지 않는 파일 형식입니다. PNG 또는 JPG 파일만 업로드 가능합니다.',
   IMAGE_SIZE_TOO_LARGE: '이미지 크기는 3MB 이하로 업로드 가능합니다.'
@@ -40,4 +40,3 @@ export const ChallengePostSchema = {
   CATEGORY_SCHEMA: z.string({ required_error: '카테고리를 선택해 주세요.' }),
   EXECUTE_DAYS_SCHEMA: z.array(z.string()).min(1, '실행 요일을 선택해 주세요.')
 };
-

--- a/src/lib/api/challenge-post.api.ts
+++ b/src/lib/api/challenge-post.api.ts
@@ -1,5 +1,5 @@
 import { ChallengePost } from '@/types/challenge.type';
-import { DATABASE, FETCH_MESSAGES } from '@/constants/challenge-post.constants';
+import { CHALLENGE_API_MESSAGES, DATABASE } from '@/constants/challenge-post.constants';
 import browserClient from '../supabase/client';
 import { validateChallengePost, validateFile } from '../utils/validate.util';
 import { fetchUploadImage } from './storage.api';
@@ -23,7 +23,7 @@ export const fetchCreateChallenge = async (
 
   // 사용자 정보 확인
   const { userId } = await getUserInfo();
-  if (!userId) return { success: false, message: FETCH_MESSAGES.LOGIN_REQUIRED };
+  if (!userId) return { success: false, message: CHALLENGE_API_MESSAGES.AUTH.LOGIN_REQUIRED };
 
   // 이미지 업로드
   const { imageUrl, error: uploadError } = await fetchUploadChallengeImage(challengeImageFile);
@@ -37,10 +37,10 @@ export const fetchCreateChallenge = async (
     const result = await browserClient.from(DATABASE.TABLES.CHALLENGES).insert(payload).select().single();
 
     if (result.error) throw result.error;
-    return { success: true, message: '챌린지 생성 성공' };
+    return { success: true, message: CHALLENGE_API_MESSAGES.CREATION.SUCCESS };
   } catch (error) {
     console.error('챌린지 생성 오류:', error);
-    return { success: false, message: '챌린지 생성에 실패했습니다.' };
+    return { success: false, message: CHALLENGE_API_MESSAGES.CREATION.FAILED };
   }
 };
 
@@ -59,7 +59,7 @@ export const fetchUpdateChallenge = async (
   // 챌린지 데이터 조회
   const existingChallenge = await fetchGetChallengeById(challengeId);
   if (!existingChallenge) {
-    return { success: false, message: '해당 챌린지를 찾을 수 없습니다.' };
+    return { success: false, message: CHALLENGE_API_MESSAGES.UPDATE.NOT_FOUND };
   }
 
   // 입력 검증
@@ -68,11 +68,11 @@ export const fetchUpdateChallenge = async (
 
   // 사용자 정보 확인
   const { userId } = await getUserInfo();
-  if (!userId) return { success: false, message: FETCH_MESSAGES.LOGIN_REQUIRED };
+  if (!userId) return { success: false, message: CHALLENGE_API_MESSAGES.AUTH.LOGIN_REQUIRED };
 
   // `creator_id`가 일치하는지 확인
   if (existingChallenge.creatorId !== userId) {
-    return { success: false, message: '이 챌린지의 수정 권한이 없습니다.' };
+    return { success: false, message: CHALLENGE_API_MESSAGES.UPDATE.UNAUTHORIZED };
   }
 
   // 이미지 업로드
@@ -93,13 +93,13 @@ export const fetchUpdateChallenge = async (
 
     if (result.error) throw result.error;
     if (!result.data || result.data.length === 0) {
-      return { success: false, message: '챌린지 수정 반영 안됨' };
+      return { success: false, message: CHALLENGE_API_MESSAGES.UPDATE.NO_CHANGES };
     }
 
-    return { success: true, message: '챌린지 수정 성공' };
+    return { success: true, message: CHALLENGE_API_MESSAGES.UPDATE.SUCCESS };
   } catch (error) {
     console.error('챌린지 수정 오류:', error);
-    return { success: false, message: '챌린지 수정에 실패했습니다.' };
+    return { success: false, message: CHALLENGE_API_MESSAGES.UPDATE.FAILED };
   }
 };
 
@@ -119,6 +119,6 @@ const fetchUploadChallengeImage = async (
 
   const { url, error: uploadError } = await fetchUploadImage(imageFile);
   return uploadError || !url
-    ? { imageUrl: null, error: uploadError || '이미지 업로드 실패' }
+    ? { imageUrl: null, error: uploadError || CHALLENGE_API_MESSAGES.IMAGE.UPLOAD_FAILED }
     : { imageUrl: url, error: null };
 };

--- a/src/lib/api/storage.api.ts
+++ b/src/lib/api/storage.api.ts
@@ -1,6 +1,6 @@
 import browserClient from '../supabase/client';
 import { generateFileName } from '../utils/post.util';
-import { STORAGE_MESSAGES, SUPABASE_STORAGE_BUCKET } from '@/constants/challenge-post.constants';
+import { FETCH_MESSAGES, SUPABASE_STORAGE_BUCKET } from '@/constants/challenge-post.constants';
 
 /**
  * 이미지를 Supabase Storage에 업로드하는 함수
@@ -14,7 +14,7 @@ export const fetchUploadImage = async (file: File): Promise<{ url: string | null
 
   if (uploadError) {
     console.error('이미지 업로드 오류:', uploadError);
-    return { url: null, error: STORAGE_MESSAGES.IMAGE_UPLOAD_FAILED };
+    return { url: null, error: FETCH_MESSAGES.IMAGE_UPLOAD_FAILED };
   }
 
   const {

--- a/src/lib/api/storage.api.ts
+++ b/src/lib/api/storage.api.ts
@@ -1,6 +1,6 @@
 import browserClient from '../supabase/client';
 import { generateFileName } from '../utils/post.util';
-import { FETCH_MESSAGES, SUPABASE_STORAGE_BUCKET } from '@/constants/challenge-post.constants';
+import { STORAGE_MESSAGES, SUPABASE_STORAGE_BUCKET } from '@/constants/challenge-post.constants';
 
 /**
  * 이미지를 Supabase Storage에 업로드하는 함수
@@ -14,7 +14,7 @@ export const fetchUploadImage = async (file: File): Promise<{ url: string | null
 
   if (uploadError) {
     console.error('이미지 업로드 오류:', uploadError);
-    return { url: null, error: FETCH_MESSAGES.IMAGE_UPLOAD_FAILED };
+    return { url: null, error: STORAGE_MESSAGES.IMAGE_UPLOAD_FAILED };
   }
 
   const {

--- a/src/lib/hooks/use-challenge-post-mutation.ts
+++ b/src/lib/hooks/use-challenge-post-mutation.ts
@@ -9,19 +9,18 @@ type UseChallengePostMutationParams = {
   challengeId?: number;
 };
 
+type ChallengeMutationResponse = {
+  success: boolean;
+  message: string;
+};
+
 const useChallengePostMutation = ({
   isEditMode,
   challenge,
   challengeImageFile,
   challengeId
 }: UseChallengePostMutationParams) => {
-  return useMutation<
-    {
-      success: boolean;
-      message: string;
-    },
-    Error
-  >({
+  return useMutation<ChallengeMutationResponse, Error>({
     mutationFn: async () => {
       if (isEditMode) {
         if (challengeId === undefined) throw new Error('챌린지 ID가 없습니다.');

--- a/src/lib/hooks/use-challenge-post-mutation.ts
+++ b/src/lib/hooks/use-challenge-post-mutation.ts
@@ -1,14 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
 import { ChallengePost } from '@/types/challenge.type';
 import { fetchCreateChallenge, fetchUpdateChallenge } from '../api/challenge-post.api';
-import { useRouter } from 'next/navigation';
 
-interface UseChallengePostMutationParams {
+type UseChallengePostMutationParams = {
   isEditMode: boolean;
   challenge: ChallengePost;
   challengeImageFile: File | null;
   challengeId?: number;
-}
+};
 
 const useChallengePostMutation = ({
   isEditMode,
@@ -16,31 +15,21 @@ const useChallengePostMutation = ({
   challengeImageFile,
   challengeId
 }: UseChallengePostMutationParams) => {
-  const router = useRouter();
-
-  const { mutate, isPending } = useMutation({
+  return useMutation<
+    {
+      success: boolean;
+      message: string;
+    },
+    Error
+  >({
     mutationFn: async () => {
       if (isEditMode) {
         if (challengeId === undefined) throw new Error('챌린지 ID가 없습니다.');
         return fetchUpdateChallenge(challengeId, challenge, challengeImageFile);
-      } else {
-        return fetchCreateChallenge(challenge, challengeImageFile);
       }
-    },
-    onSuccess: (data) => {
-      if (data.success) {
-        alert(data.message);
-        router.push(isEditMode ? `/challenges/${challengeId}` : '/home');
-      } else {
-        alert(`${data.message}`);
-      }
-    },
-    onError: (error) => {
-      alert(`${error instanceof Error ? error.message : '알 수 없는 오류'}`);
+      return fetchCreateChallenge(challenge, challengeImageFile);
     }
   });
-
-  return { mutate, isPending }; // mutate로 반환
 };
 
 export default useChallengePostMutation;

--- a/src/lib/utils/post.util.ts
+++ b/src/lib/utils/post.util.ts
@@ -7,12 +7,12 @@ import { ChallengePost } from '@/types/challenge.type';
  * @returns {string} - 조건에 맞는 클래스 이름
  */
 export const getDayCheckboxClass = (day: string, executeDays: string[]): string => {
-  let buttonClass = 'h-8 w-8 rounded-full border cursor-pointer';
+  let buttonClass = ' h-9 w-9 rounded-full border-2 cursor-pointer transition-all duration-200 ease-in-out';
 
   if (executeDays.includes(day)) {
-    buttonClass += ' bg-primary border-red-700';
+    buttonClass += 'shadow-sm scale-105 bg-primary border-secondary';
   } else {
-    buttonClass += ' border-border hover:bg-primary hover:border-red-700 ';
+    buttonClass += 'border-border hover:bg-accent hover:border-secondary-foreground bg-primary-foreground';
   }
 
   return buttonClass;
@@ -25,12 +25,12 @@ export const getDayCheckboxClass = (day: string, executeDays: string[]): string 
  * @returns {string} - 조건에 맞는 클래스 이름
  */
 export const getCategoryRadioClass = (category: string, selectedCategory: string): string => {
-  let buttonClass = 'cursor-pointer rounded-full border';
+  let buttonClass = 'cursor-pointer rounded-full border-2 transition-all duration-300';
 
   if (selectedCategory === category) {
-    buttonClass += ' opacity-100 border-red-700';
+    buttonClass += ' bg-primary text-primary-foreground shadow-md border-secondary';
   } else {
-    buttonClass += ' opacity-40 hover:opacity-100';
+    buttonClass += 'border-muted bg-muted/30 hover:bg-accent hover:border-secondary-foreground';
   }
 
   return buttonClass;


### PR DESCRIPTION
## 💡 관련이슈
> - close #52 

## 🍀 작업 요약
> 챌린지 생성 및 수정 페이지 UI/UX 개선 + 약간의 리팩토링
- UI 개선 + `mb-6` 이던 부분들 `flex flex-col gap-6 ` 이런식으로 변경했습니다.
- 자신이 아닌 작성글을 path url로 접근하려 할경우 '/home'으로 이동하게 만들었습니다.
- useMutation에 ui 관련 로직이 있었는데 뺐습니다.

## 💬 리뷰 요구 사항
> UI 위주로 리뷰 부탁드릴게요!

## 💛 미리보기
> ### 변경 전

<img width="1436" alt="스크린샷 2025-03-27 오전 2 10 11" src="https://github.com/user-attachments/assets/303d0f71-a77b-4d59-80b2-04513120ff42" />

> ### 변경 후
![ㅇㅇㅇㅇㅇ](https://github.com/user-attachments/assets/ce305f65-ad68-4706-8811-fe1f1094b716)
