### PR TITLE
Refact/#74 전역 페이지 toastify 적용하기 및 하드코딩 제거

### DIFF
--- a/src/components/features/auth/auth-sign-in-form.tsx
+++ b/src/components/features/auth/auth-sign-in-form.tsx
@@ -10,6 +10,7 @@ import ICON_GITHUB from '@/../public/images/icon-github.png';
 import ICON_GOOGLE from '@/../public/images/icon-google.png';
 import AuthToggleLink from './auth-toggle-link';
 import { PROJECT_URL } from '@/constants/env.constant';
+import APP_URL from '@/constants/app-url.constant';
 
 /**
  * @function useSignInForm : 로그인 Form 제출 관리 훅
@@ -42,7 +43,7 @@ const AuthSignInForm = () => {
   const onSubmit = async () => {
     const values = form.getValues();
     await browserClient.auth.signInWithPassword(values);
-    window.location.href = '/home';
+    window.location.href = APP_URL.HOME;
   };
 
   return (

--- a/src/components/features/challenges/post/challenge-post-button-group.tsx
+++ b/src/components/features/challenges/post/challenge-post-button-group.tsx
@@ -4,6 +4,7 @@ import URL from '@/constants/app-url.constant';
 import useChallengePostMutation from '@/lib/hooks/use-challenge-post-mutation';
 import { ChallengePost } from '@/types/challenge.type';
 import { useRouter } from 'next/navigation';
+import { toast } from 'react-toastify';
 
 type ChallengePostButtonGroupProps = {
   challenge: ChallengePost;
@@ -30,14 +31,14 @@ const ChallengePostButtonGroup = ({
     try {
       const result = await mutateAsync();
       if (result.success) {
-        alert(isEditMode ? '챌린지 수정 완료!' : '챌린지 생성 완료!');
+        toast.success(isEditMode ? '챌린지 수정 완료!' : '챌린지 생성 완료!');
         router.push(isEditMode ? APP_URL.CHALLENGES_ID(challengeId!) : APP_URL.HOME);
       } else {
-        alert(`오류: ${result.message}`);
+        toast.error(`오류: ${result.message}`);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : '알 수 없는 오류';
-      alert(`오류 발생: ${message}`);
+      toast.error(`오류 발생: ${message}`);
     }
   };
 

--- a/src/components/features/my-page/my-page-edit-profile.tsx
+++ b/src/components/features/my-page/my-page-edit-profile.tsx
@@ -97,7 +97,7 @@ const MyPageEditProfile = ({ setSelectedTab }: MyPageEditProfileProps) => {
       .update({ nickname: nickname, profile_image: profileImageUrl })
       .eq('id', data.user.id);
 
-    if (updateError) return alert(ErrorMessage.NOT_UPDATED_PROFILE);
+    if (updateError) return toast.error(ErrorMessage.NOT_UPDATED_PROFILE);
     toast.success(TOAST_MESSAGES.SUCCESS_PROFILE_UPDATE);
     setNickname(nickname);
   };

--- a/src/components/features/my-page/my-page-edit-profile.tsx
+++ b/src/components/features/my-page/my-page-edit-profile.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-/**
- * 마이페이지 프로필 수정 컴포넌트
- * @param {Object} props - 컴포넌트 프로퍼티
- * @param {Function} props.setSelectedTab - 탭 선택 핸들러
- */
 import React, { useEffect, useRef, useState } from 'react';
 import browserClient from '@/lib/supabase/client';
 import Link from 'next/link';
@@ -24,6 +19,12 @@ import { useGetMyChallengesCompletionsTodayQuery } from '@/lib/queries/use-get-m
 import { useGetMyInProgressChallengesQuery } from '@/lib/queries/use-get-my-in-progress-challenges-query';
 import { useGetMyCompletedChallengesQuery } from '@/lib/queries/use-get-my-completed-challenges-query';
 import { TOAST_MESSAGES } from '@/constants/my-page-constant';
+
+/**
+ * 마이페이지 프로필 수정 컴포넌트
+ * @param {Object} props - 컴포넌트 프로퍼티
+ * @param {Function} props.setSelectedTab - 탭 선택 핸들러
+ */
 
 const MyPageEditProfile = ({ setSelectedTab }: MyPageEditProfileProps) => {
   const [isLoading, setIsLoading] = useState(false);

--- a/src/components/layouts/header.tsx
+++ b/src/components/layouts/header.tsx
@@ -6,13 +6,14 @@ import { getUserInfo, signOut } from '@/lib/api/user-Info.api';
 import LOGO from '../../../public/images/logo.png';
 import LOGO_HORIZONTAL from '../../../public/images/logo-horizontal.png';
 import DEFAULT_PROFILE_IMAGE from '../../../public/images/default_profile.png';
+import APP_URL from '@/constants/app-url.constant';
 
 const Header = async () => {
   const { isLogin, userInfo } = await getUserInfo();
 
   return (
     <header className="bg-primary fixed top-0 z-10 flex h-15 w-full items-center justify-between px-20 md:h-20">
-      <Link href="/home">
+      <Link href={APP_URL.HOME}>
         <Image src={LOGO} alt="헤더 로고" className="h-auto w-14 object-contain md:hidden" />
         <Image src={LOGO_HORIZONTAL} alt="헤더 로고 가로형" className="hidden h-auto w-56 object-contain md:block" />
       </Link>
@@ -26,17 +27,17 @@ const Header = async () => {
           </form>
         ) : (
           <div className="flex gap-3">
-            <Link href="/sign-in">
+            <Link href={APP_URL.SIGN_IN}>
               <Button variant="secondary">로그인</Button>
             </Link>
-            <Link href="/sign-up">
+            <Link href={APP_URL.SIGN_UP}>
               <Button variant="secondary">회원가입</Button>
             </Link>
           </div>
         )}
         {/* shadcn avatar */}
         {isLogin && (
-          <Link href="/my-page">
+          <Link href={APP_URL.MY_PAGE}>
             <Avatar className="mr-3 ml-3">
               <AvatarImage
                 src={userInfo.profile_image || DEFAULT_PROFILE_IMAGE.src}

--- a/src/components/my-page/my-page-edit-profile.tsx
+++ b/src/components/my-page/my-page-edit-profile.tsx
@@ -19,6 +19,7 @@ import RoundedImage from '../ui/rounded-image';
 import DEFAULT_IMAGE from '/public/images/default_profile.png';
 
 import type { MyPageEditProfileProps } from '@/types/my-page-type';
+import { toast } from 'react-toastify';
 
 const MyPageEditProfile = ({ setSelectedTab }: MyPageEditProfileProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -92,9 +93,9 @@ const MyPageEditProfile = ({ setSelectedTab }: MyPageEditProfileProps) => {
 
     if (updateError) {
       console.error('프로필 업데이트 실패:', updateError);
-      alert('프로필 업데이트에 실패했습니다.');
+      toast.error('프로필 업데이트에 실패했습니다.');
     } else {
-      alert('프로필이 성공적으로 업데이트되었습니다.');
+      toast.error('프로필이 성공적으로 업데이트되었습니다.');
       setNickname(nickname);
     }
   };

--- a/src/components/my-page/my-page-edit-profile.tsx
+++ b/src/components/my-page/my-page-edit-profile.tsx
@@ -47,8 +47,8 @@ const MyPageEditProfile = ({ setSelectedTab }: MyPageEditProfileProps) => {
     if (e.target.files && e.target.files[0]) {
       const file = e.target.files[0];
       // 파일 검증
-      if (!FILES.ALLOWED_TYPES.includes(file.type)) return alert(FETCH_MESSAGES.IMAGE_TYPE_INVALID);
-      if (file.size > FILES.MAX_SIZE) return alert(FETCH_MESSAGES.IMAGE_SIZE_TOO_LARGE);
+      if (!FILES.ALLOWED_TYPES.includes(file.type)) return toast.warning(FETCH_MESSAGES.IMAGE_TYPE_INVALID);
+      if (file.size > FILES.MAX_SIZE) return toast.warning(FETCH_MESSAGES.IMAGE_SIZE_TOO_LARGE);
 
       setSelectedFile(file);
       setPreviewImage(URL.createObjectURL(file)); // 미리보기 업데이트
@@ -65,7 +65,7 @@ const MyPageEditProfile = ({ setSelectedTab }: MyPageEditProfileProps) => {
     e.preventDefault();
 
     const { data, error } = await browserClient.auth.getUser();
-    if (error || !data.user) return alert(ErrorMessage.NOT_AUTHENTICATED);
+    if (error || !data.user) return toast.warning(ErrorMessage.NOT_AUTHENTICATED);
 
     let profileImageUrl = previewImage;
 
@@ -78,7 +78,7 @@ const MyPageEditProfile = ({ setSelectedTab }: MyPageEditProfileProps) => {
 
       if (uploadError) {
         console.error('이미지 업로드 실패:', uploadError);
-        return alert('이미지 업로드에 실패했습니다.');
+        return toast.warning('이미지 업로드에 실패했습니다.');
       }
 
       // 업로드된 이미지 URL 가져오기

--- a/src/lib/api/user-Info.api.ts
+++ b/src/lib/api/user-Info.api.ts
@@ -3,6 +3,7 @@ import { User, UserInfo } from '@/types/user-info.types';
 import { createClient } from '../supabase/server';
 import { transformUserData } from '@/lib/utils/transform.util';
 import { redirect } from 'next/navigation';
+import APP_URL from '@/constants/app-url.constant';
 
 const initialUserInfo = {
   id: '',
@@ -103,5 +104,5 @@ export const fetchUserInfoById = async (userId: string): Promise<User | null> =>
 export const signOut = async () => {
   const supabase = createClient();
   await supabase.auth.signOut();
-  redirect('/home');
+  redirect(APP_URL.HOME);
 };

--- a/src/lib/hooks/use-sign-in-form.ts
+++ b/src/lib/hooks/use-sign-in-form.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import browserClient from '../supabase/client';
 import { useRouter } from 'next/navigation';
 import AuthSchema from '@/constants/auth-schema.constant';
+import { toast } from 'react-toastify';
 
 const signInDefaultValues = {
   email: '',
@@ -27,8 +28,7 @@ export const useSignInForm = () => {
     });
 
     if (error) {
-      console.error(error.message);
-      alert('로그인 실패');
+      toast.error(`로그인 에러 발생 : ${error.message}`);
     }
     if (!!data.user) {
       return router.back();

--- a/src/lib/hooks/use-sign-up-form.ts
+++ b/src/lib/hooks/use-sign-up-form.ts
@@ -2,9 +2,9 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import browserClient from '../supabase/client';
-import { useRouter } from 'next/navigation';
 import AuthSchema from '@/constants/auth-schema.constant';
 import { toast } from 'react-toastify';
+import APP_URL from '@/constants/app-url.constant';
 
 const signUpDefaultValues = {
   email: '',
@@ -14,8 +14,6 @@ const signUpDefaultValues = {
 };
 
 export const useSignUpForm = () => {
-  const router = useRouter();
-
   const form = useForm({
     mode: 'onBlur',
     resolver: zodResolver(signFormSchema),
@@ -34,12 +32,14 @@ export const useSignUpForm = () => {
     });
 
     if (error) {
-      toast.error(`회원가입에 실패 하였습니다. ${error.message}`);
+      toast.error(`회원가입에 오류가 발생 하였습니다. ${error.message}`);
       return;
     }
 
     if (!!data.user) {
-      return router.back();
+      toast.success('회원가입이 완료되었습니다.');
+      window.location.href = APP_URL.HOME;
+      return;
     }
   };
 

--- a/src/lib/hooks/use-sign-up-form.ts
+++ b/src/lib/hooks/use-sign-up-form.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import browserClient from '../supabase/client';
 import { useRouter } from 'next/navigation';
 import AuthSchema from '@/constants/auth-schema.constant';
+import { toast } from 'react-toastify';
 
 const signUpDefaultValues = {
   email: '',
@@ -33,8 +34,8 @@ export const useSignUpForm = () => {
     });
 
     if (error) {
-      console.error(error.message);
-      return alert('회원가입 실패');
+      toast.error(`회원가입에 실패 하였습니다. ${error.message}`);
+      return;
     }
 
     if (!!data.user) {


### PR DESCRIPTION
## 💡 관련이슈
> - close #74 

## 🍀 작업 요약
- [x] :  전체 페이지 내에서 사용된 alert를 toast를 사용하여 변경
- [x] :  매직 넘버/ 하드 코딩으로 작성된 URL을 상수로 적용
- [x] :  회원가입시 login 상태 반영 안되는 문제를 같이 해결

## 💬 리뷰 요구 사항
> 돌아다니면서 보이는 곳은 바꿨는데 적용 안된 곳 도 있을 것 같습니다! 

## 💛 미리보기

![image](https://github.com/user-attachments/assets/ecb06f54-1166-4dce-b98d-193a153dbcb8)

